### PR TITLE
FIX: string padding not working if add first string to strings

### DIFF
--- a/sii.c
+++ b/sii.c
@@ -191,18 +191,17 @@ static void strings_entry_add(struct _sii_strings *str, struct _string *new)
 {
 	if (str->head == NULL) { /* first entry */
 		str->head = new;
-		str->count = 1;
 		new->id = 1;
-		return;
+	} else {
+		struct _string *s = str->head;
+		while (s->next)
+			s = s->next;
+
+		s->next = new;
+		new->prev = s;
+		new->id = s->id+1;
 	}
 
-	struct _string *s = str->head;
-	while (s->next)
-		s = s->next;
-
-	s->next = new;
-	new->prev = s;
-	new->id = s->id+1;
 	str->count += 1;
 	str->size += new->length;
 	str->padbyte = (str->size % 2) ? 0 : 1;


### PR DESCRIPTION
Generated BIN file is invalid if first <Name> tag in XML contains string with odd size