### PR TITLE
FIX: use cmalloc where usefull to be sure for initialized memory

### DIFF
--- a/esi.c
+++ b/esi.c
@@ -217,7 +217,7 @@ static xmlNode *search_children(xmlNode *root, const char *name)
 /* functions to parse xml */
 static struct _sii_preamble *parse_preamble(xmlNode *node)
 {
-	struct _sii_preamble *pa = malloc(sizeof(struct _sii_preamble));
+	struct _sii_preamble *pa = calloc(1, sizeof(struct _sii_preamble));
 
 	char string[1024];
 	strncpy(string, (char *)node->children->content, 1024);
@@ -263,15 +263,13 @@ static struct _sii_stdconfig *parse_config(xmlNode *root)
 {
 	xmlNode *n, *tmp;
 
-	struct _sii_stdconfig *sc = malloc(sizeof(struct _sii_stdconfig));
-	memset(sc, 0, sizeof(struct _sii_stdconfig));
-
 	//xmlNode *n = search_node(root, "Vendor");
 	n = search_node(root, "Vendor");
 	if (n==NULL) {
-		free(sc);
 		return NULL;
 	}
+
+	struct _sii_stdconfig *sc = calloc(1, sizeof(struct _sii_stdconfig));
 
 	tmp = search_node(n, "Id");
 	//char *vendoridstr = tmp->children->content;
@@ -395,8 +393,7 @@ static struct _sii_general *parse_general(SiiInfo *sii, xmlNode *root)
 	xmlNode *parent;
 	xmlNode *node;
 	xmlNode *tmp;
-	struct _sii_general *general = malloc(sizeof(struct _sii_general));
-	memset(general, 0, sizeof(struct _sii_general));
+	struct _sii_general *general = calloc(1, sizeof(struct _sii_general));
 
 	/* Search group-,image-, order- and namestring and store these strings
 	 * to the corresponding *index.
@@ -507,18 +504,13 @@ static void parse_fmmu(xmlNode *current, SiiInfo *sii)
 {
 	struct _sii_cat *cat = sii_category_find(sii, SII_CAT_FMMU);
 	if (cat == NULL) { /* create new category */
-		cat = malloc(sizeof(struct _sii_cat));
-		cat->next = NULL;
-		cat->prev = NULL;
-		cat->data = NULL;
+		cat = calloc(1, sizeof(struct _sii_cat));
 		cat->type = SII_CAT_FMMU;
-		cat->size = 0;
 		sii_category_add(sii, cat);
 	}
 
 	if (cat->data == NULL) { /* if category exists but doesn't contain any data */
-		cat->data = (void *)malloc(sizeof(struct _sii_fmmu));
-		memset(cat->data, 0, sizeof(struct _sii_fmmu));
+		cat->data = (void *)calloc(1, sizeof(struct _sii_fmmu));
 	}
 
 	struct _sii_fmmu *fmmu = (struct _sii_fmmu *)cat->data;
@@ -542,27 +534,20 @@ static void parse_syncm(xmlNode *current, SiiInfo *sii)
 {
 	struct _sii_cat *cat = sii_category_find(sii, SII_CAT_SYNCM);
 	if (cat == NULL) {
-		cat = malloc(sizeof(struct _sii_cat));
-		cat->next = NULL;
-		cat->prev = NULL;
-		cat->data = NULL;
+		cat = calloc(1, sizeof(struct _sii_cat));
 		cat->type = SII_CAT_SYNCM;
-		cat->size = 0;
 		sii_category_add(sii, cat);
 	}
 
 	if (cat->data == NULL) {
-		cat->data = (void *)malloc(sizeof(struct _sii_syncm));
-		memset(cat->data, 0, sizeof(struct _sii_syncm));
+		cat->data = (void *)calloc(1, sizeof(struct _sii_syncm));
 	}
 
 	/* now fetch the data */
 	//size_t smsize = 0;
 	struct _sii_syncm *sm = (struct _sii_syncm *)cat->data;
-	struct _syncm_entry *entry = malloc(sizeof(struct _syncm_entry));
+	struct _syncm_entry *entry = calloc(1, sizeof(struct _syncm_entry));
 	entry->id = -1;
-	entry->next = NULL;
-	entry->prev = NULL;
 
 	xmlAttr *args = current->properties;
 	for (xmlAttr *a = args; a ; a = a->next) {
@@ -602,11 +587,8 @@ static void parse_syncm(xmlNode *current, SiiInfo *sii)
 
 static void get_dc_proto(SiiInfo *sii)
 {
-	struct _sii_cat *cat = malloc(sizeof(struct _sii_cat));
-	cat->next = NULL;
-	cat->prev = NULL;
+	struct _sii_cat *cat = calloc(1, sizeof(struct _sii_cat));
 	cat->type = SII_CAT_DCLOCK;
-	cat->size = 0;
 
 	/* now fetch the data */
 	struct _sii_dclock *dc = dclock_get_default();
@@ -619,16 +601,12 @@ static void get_dc_proto(SiiInfo *sii)
 #if 0 // FIXME this is a future feature - don't remove
 static void parse_dclock(xmlNode *current, SiiInfo *sii)
 {
-	struct _sii_cat *cat = malloc(sizeof(struct _sii_cat));
-	cat->next = NULL;
-	cat->prev = NULL;
+	struct _sii_cat *cat = calloc(1, sizeof(struct _sii_cat));
 	cat->type = SII_CAT_DCLOCK;
-	cat->size = 0;
 
 	/* now fetch the data */
 	size_t dcsize = 0;
-	struct _sii_dclock *dc = malloc(sizeof(struct _sii_dclock));
-	memset(dc, 0, sizeof(struct _sii_dclock));
+	struct _sii_dclock *dc = calloc(1, sizeof(struct _sii_dclock));
 
 	/* FIXME add entries, only use the first (default) OpMode */
 	printf("[DEBUG %s] FIXME implementation of dclock parsing is incomplete!\n", __func__);
@@ -716,10 +694,9 @@ static int parse_pdo_get_data_type(char *xmldatatype)
 
 static struct _pdo_entry *parse_pdo_entry(xmlNode *val, SiiInfo *sii)
 {
-	struct _pdo_entry *entry = malloc(sizeof(struct _pdo_entry));
-	int tmp = 0;
+	struct _pdo_entry *entry = calloc(1, sizeof(struct _pdo_entry));
 
-	memset(entry, 0, sizeof(struct _pdo_entry));
+	int tmp = 0;
 
 	for (xmlNode *child = val->children; child; child = child->next) {
 		if (xmlStrncmp(child->name, Char2xmlChar("Index"), xmlStrlen(child->name)) == 0) {
@@ -772,18 +749,13 @@ static void parse_pdo(xmlNode *current, SiiInfo *sii)
 
 	struct _sii_cat *cat = sii_category_find(sii, type);
 	if (cat == NULL) {
-		cat = malloc(sizeof(struct _sii_cat));
-		cat->next = NULL;
-		cat->prev = NULL;
-		cat->data = NULL;
+		cat = calloc(1, sizeof(struct _sii_cat));
 		cat->type = type;
-		cat->size = 0;
 		sii_category_add(sii, cat);
 	}
 
 	if (cat->data == NULL) {
-		cat->data = (void *)malloc(sizeof(struct _sii_pdo));
-		memset(cat->data, 0, sizeof(struct _sii_pdo));
+		cat->data = (void *)calloc(1, sizeof(struct _sii_pdo));
 	}
 
 	struct _sii_pdo *pdo = (struct _sii_pdo *)cat->data;
@@ -837,18 +809,12 @@ static void parse_pdo(xmlNode *current, SiiInfo *sii)
 
 struct _esi_data *esi_init(const char *file)
 {
-	struct _esi_data *esi = (struct _esi_data *)malloc(sizeof(struct _esi_data));
-	esi->sii = NULL;
-	esi->siifile = NULL;
-	esi->doc = NULL;
-	esi->xmlroot = NULL;
-	esi->xmlfile = NULL;
-
 	if (file == NULL) {
 		fprintf(stderr, "Warning, init with empty filename\n");
-		free(esi);
 		return NULL;
 	}
+
+	struct _esi_data *esi = (struct _esi_data *)calloc(1, sizeof(struct _esi_data));
 
 	enum eFileType type = efile_type(file);
 	switch (type) {
@@ -890,12 +856,7 @@ struct _esi_data *esi_init(const char *file)
 /* FIXME Input type is already given in the calling function parse_xml_input() */
 EsiData *esi_init_string(const unsigned char *buf, size_t size)
 {
-	EsiData *esi = malloc(sizeof(struct _esi_data));
-	esi->sii = NULL;
-	esi->siifile = NULL;
-	esi->doc = NULL;
-	esi->xmlroot = NULL;
-	esi->xmlfile = NULL;
+	EsiData *esi = calloc(1, sizeof(struct _esi_data));
 
 	enum eFileType type = UNKNOWN;
 
@@ -966,13 +927,9 @@ int esi_parse(EsiData *esi)
 	/* first, prepare category strings, since this is always needed */
 	struct _sii_cat *strings = sii_category_find(esi->sii, SII_CAT_STRINGS);
 	if (strings == NULL) {
-		strings = malloc(sizeof(struct _sii_cat));
-		strings->next = NULL;
-		strings->prev = NULL;
-		strings->size = 0;
+		strings = calloc(1, sizeof(struct _sii_cat));
 		strings->type = SII_CAT_STRINGS;
-		struct _sii_strings *strdata = malloc(sizeof(struct _sii_strings));
-		memset(strdata, 0, sizeof(struct _sii_strings));
+		struct _sii_strings *strdata = calloc(1, sizeof(struct _sii_strings));
 		strings->data = strdata;
 		sii_category_add(esi->sii, strings);
 	}
@@ -982,9 +939,7 @@ int esi_parse(EsiData *esi)
 	esi->sii->config = parse_config(root);
 
 	struct _sii_general *general = parse_general(esi->sii, root);
-	struct _sii_cat *gencat = malloc(sizeof(struct _sii_cat));
-	gencat->next = NULL;
-	gencat->prev = NULL;
+	struct _sii_cat *gencat = calloc(1, sizeof(struct _sii_cat));
 	gencat->type = SII_CAT_GENERAL;
 	gencat->size = sizeof(struct _sii_general);
 	gencat->data = (void *)general;

--- a/sii.c
+++ b/sii.c
@@ -66,7 +66,8 @@ static int read_eeprom(FILE *f, unsigned char *buffer, size_t size)
 
 static struct _sii_preamble * parse_preamble(const unsigned char *buffer, size_t size)
 {
-	struct _sii_preamble *preamble = malloc(sizeof(struct _sii_preamble));
+	struct _sii_preamble *preamble = calloc(1, sizeof(struct _sii_preamble));
+
 	size_t count = 0;
 	uint8_t crc = 0xff; /* init value for crc */
 
@@ -125,7 +126,9 @@ static struct _sii_stdconfig *parse_stdconfig(const unsigned char *buffer, size_
 {
 	size_t count =0;
 	const unsigned char *b = buffer;
-	struct _sii_stdconfig *stdc = malloc(sizeof(struct _sii_stdconfig));
+
+	struct _sii_stdconfig *stdc = calloc(1, sizeof(struct _sii_stdconfig));
+
 	stdc->vendor_id = BYTES_TO_DWORD(*(b+0), *(b+1), *(b+2), *(b+3));
 	b+=4;
 	stdc->product_id = BYTES_TO_DWORD(*(b+0), *(b+1), *(b+2), *(b+3));
@@ -173,16 +176,12 @@ static struct _sii_stdconfig *parse_stdconfig(const unsigned char *buffer, size_
 
 static struct _string *string_new(const char *string, size_t size)
 {
-	struct _string *new = malloc(sizeof(struct _string));
+	struct _string *new = calloc(1, sizeof(struct _string));
 
-	new->id = 0;
-	new->next = NULL;
-	new->prev = NULL;
-
-	new->data = malloc(size+1);
 	new->length = size;
-	memset(new->data, 0, size+1);
+	new->data = malloc(size+1);
 	memmove(new->data, string, size);
+	new->data[size] = 0;
 
 	return new;
 }
@@ -214,11 +213,8 @@ static struct _sii_strings *parse_string_section(const unsigned char *buffer, si
 	size_t len = 0;
 	memset(str, '\0', 1024);
 
-	struct _sii_strings *strings = (struct _sii_strings *)malloc(sizeof(struct _sii_strings));
-	strings->head = NULL;
-	strings->current = NULL;
-	strings->count = 0;
-	strings->size = 0;
+	struct _sii_strings *strings = (struct _sii_strings *)calloc(1, sizeof(struct _sii_strings));
+
 	int stringcount = *pos++;
 	int counter = 0;
 
@@ -264,7 +260,7 @@ static char *physport_type(uint8_t b)
 static struct _sii_general *parse_general_section(const unsigned char *buffer, size_t size)
 {
 	const unsigned char *b = buffer;
-	struct _sii_general *siig = malloc(sizeof(struct _sii_general));
+	struct _sii_general *siig = calloc(1, sizeof(struct _sii_general));
 
 	siig->groupindex = *b;
 	b++;
@@ -329,9 +325,7 @@ static void fmmu_rm_entry(struct _sii_fmmu *fmmu)
 
 void fmmu_add_entry(struct _sii_fmmu *fmmu, int usage)
 {
-	struct _fmmu_entry *new = malloc(sizeof(struct _fmmu_entry));
-	new->prev = NULL;
-	new->next = NULL;
+	struct _fmmu_entry *new = calloc(1, sizeof(struct _fmmu_entry));
 	new->id = -1;
 	new->usage = usage;
 
@@ -355,9 +349,7 @@ static struct _sii_fmmu *parse_fmmu_section(const unsigned char *buffer, size_t 
 {
 	const unsigned char *b = buffer;
 
-	struct _sii_fmmu *fmmu = malloc(sizeof(struct _sii_fmmu));
-	fmmu->count = 0;
-	fmmu->list = NULL;
+	struct _sii_fmmu *fmmu = calloc(1, sizeof(struct _sii_fmmu));
 
 	while ((unsigned int)(b-buffer)<secsize) {
 		fmmu_add_entry(fmmu, *b);
@@ -407,10 +399,8 @@ void syncm_entry_add(struct _sii_syncm *sm, struct _syncm_entry *entry)
 static void syncm_add_entry(struct _sii_syncm *sm,
 		int phys_address, int length, int control, int status, int enable, int type)
 {
-	struct _syncm_entry *entry = malloc(sizeof(struct _syncm_entry));
+	struct _syncm_entry *entry = calloc(1, sizeof(struct _syncm_entry));
 	entry->id = -1;
-	entry->next = NULL;
-	entry->prev = NULL;
 	entry->phys_address = phys_address;
 	entry->length = length;
 	entry->control = control;
@@ -442,9 +432,7 @@ static struct _sii_syncm *parse_syncm_section(const unsigned char *buffer, size_
 	int smnbr = 0;
 	const unsigned char *b = buffer;
 
-	struct _sii_syncm *sm = malloc(sizeof(struct _sii_syncm));
-	sm->list = NULL;
-	sm->count = 0;
+	struct _sii_syncm *sm = calloc(1, sizeof(struct _sii_syncm));
 
 	while (count<secsize) {
 		int physadr = BYTES_TO_WORD(*b, *(b+1));
@@ -511,7 +499,7 @@ static void pdo_add_entry(struct _sii_pdo *pdo,
 		int index, int subindex, int string_index, int data_type,
 		int bit_length, int flags)
 {
-	struct _pdo_entry *entry = malloc(sizeof(struct _pdo_entry));
+	struct _pdo_entry *entry = calloc(1, sizeof(struct _pdo_entry));
 
 	entry->id = -1;
 	entry->index = index;
@@ -520,8 +508,6 @@ static void pdo_add_entry(struct _sii_pdo *pdo,
 	entry->data_type = data_type;
 	entry->bit_length = bit_length;
 	entry->flags = flags;
-	entry->next = NULL;
-	entry->prev = NULL;
 
 	/* FIXME make use of pdo_entry_add() */
 	if (pdo->list == NULL) {
@@ -544,8 +530,7 @@ static struct _sii_pdo *parse_pdo_section(const unsigned char *buffer, size_t se
 	const unsigned char *b = buffer;
 	int entry = 0;
 
-	struct _sii_pdo *pdo = malloc(sizeof(struct _sii_pdo));
-	memset(pdo, 0, sizeof(struct _sii_pdo));
+	struct _sii_pdo *pdo = calloc(1, sizeof(struct _sii_pdo));
 
 	switch (t) {
 	case RxPDO:
@@ -610,8 +595,7 @@ static struct _sii_dclock *parse_dclock_section(const unsigned char *buffer, siz
 {
 	const unsigned char *b = buffer;
 
-	struct _sii_dclock *dc = malloc(sizeof(struct _sii_dclock));
-	memset(dc, 0, sizeof(struct _sii_dclock));
+	struct _sii_dclock *dc = calloc(1, sizeof(struct _sii_dclock));
 
 	b++; /* first byte is reserved */
 
@@ -933,14 +917,12 @@ static void cat_data_cleanup(struct _sii_cat *cat)
 #if 0
 static struct _sii_cat *cat_new_data(uint16_t type, uint16_t size, void *data)
 {
-	struct _sii_cat *new = malloc(sizeof(struct _sii_cat));
+	struct _sii_cat *new = calloc(1, sizeof(struct _sii_cat));
 
 	new->type   = type&0x7fff;
 	new->vendor = (type>>16)&0x1;
 	new->size   = size;
 	new->data   = data;
-	new->next   = NULL;
-	new->prev   = NULL;
 
 	return new;
 }
@@ -948,14 +930,11 @@ static struct _sii_cat *cat_new_data(uint16_t type, uint16_t size, void *data)
 
 static struct _sii_cat *cat_new(uint16_t type, uint16_t size)
 {
-	struct _sii_cat *new = malloc(sizeof(struct _sii_cat));
+	struct _sii_cat *new = calloc(1, sizeof(struct _sii_cat));
 
 	new->type   = type&0x7fff;
 	new->vendor = (type>>16)&0x1;
 	new->size   = size;
-	new->data   = NULL;
-	new->next   = NULL;
-	new->prev   = NULL;
 
 	return new;
 }
@@ -1948,32 +1927,18 @@ static void sii_write(SiiInfo *sii)
 
 SiiInfo *sii_init(void)
 {
-	SiiInfo *sii = malloc(sizeof(SiiInfo));
-
-	sii->cat_head = NULL;
-	sii->cat_current = NULL;
-	sii->outfile = NULL;
-	sii->rawbytes = NULL;
-	sii->rawvalid = 0;
-
+	SiiInfo *sii = calloc(1, sizeof(SiiInfo));
 	return sii;
 }
 
 SiiInfo *sii_init_string(const unsigned char *eeprom, size_t size)
 {
-	SiiInfo *sii = malloc(sizeof(SiiInfo));
-
 	if (eeprom == NULL) {
 		fprintf(stderr, "No eeprom provided\n");
-		free(sii);
 		return NULL;
 	}
 
-	sii->cat_head = NULL;
-	sii->cat_current = NULL;
-	sii->rawbytes = NULL;
-	sii->rawvalid = 0;
-	sii->outfile = NULL;
+	SiiInfo *sii = calloc(1, sizeof(SiiInfo));
 
 	parse_content(sii, eeprom, size);
 
@@ -1982,23 +1947,15 @@ SiiInfo *sii_init_string(const unsigned char *eeprom, size_t size)
 
 SiiInfo *sii_init_file(const char *filename)
 {
-	SiiInfo *sii = malloc(sizeof(SiiInfo));
-	unsigned char eeprom[1024];
-
-	if (filename != NULL)
-		read_eeprom(stdin, eeprom, 1024);
-	else {
+	if (filename == NULL) {
 		fprintf(stderr, "Error no filename provided\n");
-		free(sii);
 		return NULL;
 	}
 
-	sii->cat_head = NULL;
-	sii->cat_current = NULL;
-	sii->rawbytes = NULL;
-	sii->rawvalid = 0;
-	sii->outfile = NULL;
+	SiiInfo *sii = calloc(1, sizeof(SiiInfo));
+	unsigned char eeprom[1024];
 
+	read_eeprom(stdin, eeprom, 1024);
 	parse_content(sii, eeprom, 1024);
 
 	return sii;
@@ -2028,9 +1985,7 @@ void sii_release(SiiInfo *sii)
 size_t sii_generate(SiiInfo *sii)
 {
 	size_t maxsize = sii->config->eeprom_size * 1024;
-	sii->rawbytes = (uint8_t*) malloc(maxsize);
-	memset(sii->rawbytes, 0, maxsize);
-	sii->rawsize = 0;
+	sii->rawbytes = (uint8_t*) calloc(1, maxsize);
 
 	sii_write(sii);
 	sii->rawvalid = 1; /* FIXME valid should be set in sii_write */


### PR DESCRIPTION
this fixes a init problem regarding SM config.
Some cleanup also.
Important also for fix-parse-eeprom-config-data
