### PR TITLE
Add files via upload

### DIFF
--- a/main.c
+++ b/main.c
@@ -47,7 +47,7 @@
 #include <stdlib.h>
 #include <errno.h>
 
-#define MAX_BUFFER_SIZE    (1000*1024)
+#define MAX_BUFFER_SIZE    (10000*1024)
 #define MAX_FILENAME_SIZE  (256)
 
 enum eInputFileType {
@@ -233,7 +233,7 @@ static int parse_sii_input(const unsigned char *buffer, const char *output)
 int main(int argc, char *argv[])
 {
 	FILE *f;
-	unsigned char eeprom[MAX_BUFFER_SIZE];
+	unsigned char *eeprom = malloc(MAX_BUFFER_SIZE);
 	char *filename = NULL;
 	char *output = NULL;
 	int ret = -1;


### PR DESCRIPTION
This change fixes the segfault when loading a large ESI file.
There are two changes in the file main.c:
MAX_BUFFER_SIZE was increased to 10 Mbytes.
The eeprom buffer is now dynamically allocated (malloc) instead of being a stack allocation.