### PR TITLE
issue 12: allow hex or dec input for uint parameters

### DIFF
--- a/esi.c
+++ b/esi.c
@@ -23,6 +23,11 @@ struct _esi_data {
 	char *xmlfile;
 };
 
+#define scanHexDec(str,pobj) do{\
+    if(sscanf(str, "#x%x", pobj) != 1)\
+		sscanf(str, "%u", pobj);\
+}while(0);\
+
 static char *type2str(int type)
 {
 	switch (type) {
@@ -298,7 +303,7 @@ static struct _sii_stdconfig *parse_config(xmlNode *root)
 
 	/* get id */
 	// FIXME add some error and validty checking, esp. if node is set correctly and has the type
-	sscanf((const char *)tmp->children->content, "#x%x", &(sc->vendor_id));
+	scanHexDec((const char *)tmp->children->content, &(sc->vendor_id));
 
 	n = search_node(search_node(root, "Devices"), "Device");
 
@@ -307,11 +312,11 @@ static struct _sii_stdconfig *parse_config(xmlNode *root)
 
 	while (prop != NULL) {
 		if (xmlStrncmp(prop->name, Char2xmlChar("ProductCode"), xmlStrlen(prop->name)) == 0) {
-			sscanf((const char *)prop->children->content, "#x%x", &(sc->product_id));
+			scanHexDec((const char *)prop->children->content, &(sc->product_id));
 		}
 
 		if (xmlStrncmp(prop->name, Char2xmlChar("RevisionNo"), xmlStrlen(prop->name)) == 0) {
-			sscanf((const char *)prop->children->content, "#x%x", &(sc->revision_id));
+			scanHexDec((const char *)prop->children->content, &(sc->revision_id));
 		}
 
 		prop = prop->next;
@@ -345,7 +350,7 @@ static struct _sii_stdconfig *parse_config(xmlNode *root)
 
 						if (xmlStrncmp(p->name, Char2xmlChar("StartAddress"), xmlStrlen(p->name)) == 0) {
 							unsigned int atmp = 0;
-							sscanf((const char *)p->children->content, "#x%x", &atmp);
+							scanHexDec((const char *)p->children->content, &atmp);
 							sc->std_rec_mbox_offset = atmp;
 						}
 
@@ -363,7 +368,7 @@ static struct _sii_stdconfig *parse_config(xmlNode *root)
 
 						if (xmlStrncmp(p->name, Char2xmlChar("StartAddress"), xmlStrlen(p->name)) == 0) {
 							unsigned int atmp = 0;
-							sscanf((const char *)p->children->content, "#x%x", &atmp);
+							scanHexDec((const char *)p->children->content, &atmp);
 							sc->std_snd_mbox_offset = atmp;
 						}
 
@@ -597,11 +602,11 @@ static void parse_syncm(xmlNode *current, SiiInfo *sii)
 			entry->length = atoi((char *)a->children->content);
 		} else if (xmlStrncmp(a->name, Char2xmlChar("StartAddress"), xmlStrlen(a->name)) == 0) {
 			int tmp = 0;
-			sscanf((char *)a->children->content, "#x%x", &tmp);
+			scanHexDec((char *)a->children->content, &tmp);
 			entry->phys_address = tmp&0xffff;
 		} else if (xmlStrncmp(a->name, Char2xmlChar("ControlByte"), xmlStrlen(a->name)) == 0) {
 			int tmp = 0;
-			sscanf((char *)a->children->content, "#x%x", &tmp);
+			scanHexDec((char *)a->children->content, &tmp);
 			entry->control = tmp&0xff;
 		} else if (xmlStrncmp(a->name, Char2xmlChar("Enable"), xmlStrlen(a->name)) == 0) {
 			entry->enable = atoi((char *)a->children->content);
@@ -742,7 +747,7 @@ static struct _pdo_entry *parse_pdo_entry(xmlNode *val, SiiInfo *sii)
 
 	for (xmlNode *child = val->children; child; child = child->next) {
 		if (xmlStrncmp(child->name, Char2xmlChar("Index"), xmlStrlen(child->name)) == 0) {
-			sscanf((char *)child->children->content, "#x%x", &tmp);
+			scanHexDec((char *)child->children->content, &tmp);
 			entry->index = tmp&0xffff;
 			tmp = 0;
 		} else if (xmlStrncmp(child->name, Char2xmlChar("SubIndex"), xmlStrlen(child->name)) == 0) {
@@ -840,7 +845,7 @@ static void parse_pdo(xmlNode *current, SiiInfo *sii)
 			}
 		} else if (xmlStrncmp(val->name, Char2xmlChar("Index"), xmlStrlen(val->name)) == 0) {
 			int tmp = 0;
-			sscanf((char *)val->children->content, "#x%x", &tmp);
+			scanHexDec((char *)val->children->content, &tmp);
 			pdo->index = tmp&0xffff;
 		} else if (xmlStrncmp(val->name, Char2xmlChar("Entry"), xmlStrlen(val->name)) == 0) {
 			/* add new pdo entry */


### PR DESCRIPTION
A lot of esi files come with vendor ID in decimal format. According to ESI specification both formats are allowed for a "HexDecValue" type. 