### PR TITLE
Don't use valid category numbers for SII_PREAMBLE and SII_STD_CONFIG

### DIFF
--- a/sii.h
+++ b/sii.h
@@ -28,9 +28,9 @@
 #define BYTES_TO_EE(x) ((x - 0x80) >> 7)
 
 enum eSection {
-	SII_CAT_NOP
-	,SII_PREAMBLE
-	,SII_STD_CONFIG
+	SII_PREAMBLE = -1
+	,SII_STD_CONFIG = -2
+	,SII_CAT_NOP = 0
 	,SII_CAT_STRINGS = 10
 	,SII_CAT_DATATYPES = 20 /* future use */
 	,SII_CAT_GENERAL = 30


### PR DESCRIPTION
According to Table 19 in ETG1000/6 the values used for SII_PREABMLE and
SII_STD_CONFIG could be allocated as "Device specific" categories. This
patch assigns them new numbers that don't clash with valied categories.

Without this patch, the tool will hang if an eeprom have category 1
entries.