### PR TITLE
[fix]compile warning [-Wstringop-truncation]

### DIFF
--- a/esi.c
+++ b/esi.c
@@ -263,8 +263,8 @@ static struct _sii_preamble *parse_preamble(xmlNode *node)
 {
 	struct _sii_preamble *pa = calloc(1, sizeof(struct _sii_preamble));
 
-	char string[1024];
-	strncpy(string, (char *)node->children->content, 1024);
+	char string[1025];
+	strncpy(string, (char *)node->children->content, sizeof(string) - 1);
 
 	unsigned int lowbyte=0, highbyte=0;
 	char *b = string;


### PR DESCRIPTION
Compile in gcc 11.4.0,
```
In file included from /usr/include/string.h:535,
                 from esi.c:9:
In function ‘strncpy’,
    inlined from ‘parse_preamble’ at esi.c:267:2:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:95:10: warning: ‘__builtin_strncpy’ specified bound 1024 equals destination size [-Wstringop-truncation]
   95 |   return __builtin___strncpy_chk (__dest, __src, __len,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   96 |                                   __glibc_objsize (__dest));
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~
``` 