### PR TITLE
fix: Parsing DefaultSize data for MBoxOut/In when in hex value

### DIFF
--- a/esi.c
+++ b/esi.c
@@ -614,7 +614,9 @@ static void parse_syncm(xmlNode *current, SiiInfo *sii)
 	xmlAttr *args = current->properties;
 	for (xmlAttr *a = args; a ; a = a->next) {
 		if (xmlStrncmp(a->name, Char2xmlChar("DefaultSize"), xmlStrlen(a->name)) == 0) {
-			entry->length = atoi((char *)a->children->content);
+			uint32_t tmp = 0;
+			scan_hex_dec((char *)a->children->content, &tmp);
+			entry->length = tmp&0xffff;
 		} else if (xmlStrncmp(a->name, Char2xmlChar("StartAddress"), xmlStrlen(a->name)) == 0) {
 			uint32_t tmp = 0;
 			scan_hex_dec((char *)a->children->content, &tmp);


### PR DESCRIPTION
Hi,

There was an issue about this bug: https://github.com/synapticon/siitool/issues/17

I replaced the use of the scan_hex_dec function with atoi for parsing the DefaultSize of the mailbox. This change ensures that the data is parsed properly. When using atoi for parsing, the MBoxOut/In data length was being incorrectly set to 0 when in hexadecimal value.